### PR TITLE
Remove >= from cabal-version

### DIFF
--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -20,7 +20,7 @@ maintainer:          Roman Cheplyaka <roma@ro-che.info>
 -- copyright:
 category:            Testing
 build-type:          Simple
-cabal-version:       >=1.14
+cabal-version:       1.14
 extra-source-files:
   CHANGELOG.md
   example/golden/fail/*.golden


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: tasty-golden.cabal:23:28: Packages with 'cabal-version: 1.12' or                                                                                                                                                                               
later should specify a specific version of the Cabal spec of the form                                                                                                                                                                                                              
'cabal-version: x.y'. Use 'cabal-version: 1.14'.
```