### PR TITLE
Do not depend on unix-compat

### DIFF
--- a/tasty-golden.cabal
+++ b/tasty-golden.cabal
@@ -66,8 +66,7 @@ library
     containers,
     directory,
     async,
-    text,
-    unix-compat
+    text
 
 Test-suite test
   Default-language:


### PR DESCRIPTION
Currently `tasty-golden` cannot be used on Windows with GHC 9.0.2 or 9.2.1 because of `unix-compat` lagging behind `Win32` with https://github.com/jacobstanley/unix-compat/pull/47 open since May. This PR eliminates dependency on `unix-compat` as suggested by @RyanGlScott  in https://github.com/UnkindPartition/tasty-golden/pull/38/#issuecomment-626352914.